### PR TITLE
Close channel

### DIFF
--- a/pkg/pipe/Builder.go
+++ b/pkg/pipe/Builder.go
@@ -46,6 +46,11 @@ func (b *Builder) Input(in Iterator) *Builder {
 	}
 }
 
+// InputF sets the input for the pipeline to a function by wrapping the provided function with pipe.FunctionIterator.
+func (b *Builder) InputF(fn func() (interface{}, error)) *Builder {
+	return b.Input(NewFunctionIterator(fn))
+}
+
 // Output sets the output for the pipeline.
 func (b *Builder) Output(w Writer) *Builder {
 	return &Builder{
@@ -60,8 +65,7 @@ func (b *Builder) Output(w Writer) *Builder {
 	}
 }
 
-// Output sets the output for the pipeline to a function.
-// Wraps the provided function with pipe.FunctionWriter.
+// OutputF sets the output for the pipeline to a function by wrapping the provided function with pipe.FunctionWriter.
 func (b *Builder) OutputF(fn func(object interface{}) error) *Builder {
 	return b.Output(NewFunctionWriter(fn))
 }

--- a/pkg/pipe/ChannelWriter.go
+++ b/pkg/pipe/ChannelWriter.go
@@ -7,22 +7,33 @@
 
 package pipe
 
+import (
+	"reflect"
+)
+
 // ChannelWriter passes each object to the callback function
 type ChannelWriter struct {
-	channel chan interface{}
+	channel reflect.Value
 }
 
-func NewChannelWriter(channel chan interface{}) *ChannelWriter {
-	return &ChannelWriter{
-		channel: channel,
+func NewChannelWriter(channel interface{}) (*ChannelWriter, error) {
+	v := reflect.ValueOf(channel)
+	if k := v.Type().Kind(); k != reflect.Chan {
+		return nil, &ErrInvalidKind{Value: v.Type(), Expected: []reflect.Kind{reflect.Chan}}
 	}
+	return &ChannelWriter{channel: v}, nil
 }
 
 func (cw *ChannelWriter) WriteObject(object interface{}) error {
-	cw.channel <- object
+	cw.channel.Send(reflect.ValueOf(object))
 	return nil
 }
 
 func (cw *ChannelWriter) Flush() error {
+	return nil
+}
+
+func (cw *ChannelWriter) Close() error {
+	cw.channel.Close()
 	return nil
 }

--- a/pkg/pipe/ChannelWriter_examples_test.go
+++ b/pkg/pipe/ChannelWriter_examples_test.go
@@ -16,9 +16,12 @@ func ExampleChannelWriter() {
 
 	c := make(chan interface{}, 1000)
 
-	w := NewChannelWriter(c)
+	w, err := NewChannelWriter(c)
+	if err != nil {
+		panic(err)
+	}
 
-	err := w.WriteObject("a")
+	err = w.WriteObject("a")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/pipe/ChannelWriter_test.go
+++ b/pkg/pipe/ChannelWriter_test.go
@@ -17,9 +17,12 @@ func TestChannelWriter(t *testing.T) {
 
 	c := make(chan interface{}, 1000)
 
-	w := NewChannelWriter(c)
+	w, err := NewChannelWriter(c)
+	if err != nil {
+		panic(err)
+	}
 
-	err := w.WriteObject("a")
+	err = w.WriteObject("a")
 	assert.Nil(t, err)
 
 	err = w.WriteObject("b")

--- a/pkg/pipe/IteratorToWriter.go
+++ b/pkg/pipe/IteratorToWriter.go
@@ -21,7 +21,7 @@ import (
 // If the filter returns true and no error, then the object is passed to the writer.
 // If the inputLimit >= 0, then reads the given number of objects from the input.
 // If the outputLimit >= 0, then writes the given number of objecst to the writer.
-func IteratorToWriter(it Iterator, w Writer, transform func(inputObject interface{}) (interface{}, error), errorHandler func(err error) error, filter func(inputObject interface{}) (bool, error), inputLimit int, outputLimit int) error {
+func IteratorToWriter(it Iterator, w Writer, transform func(inputObject interface{}) (interface{}, error), errorHandler func(err error) error, filter func(inputObject interface{}) (bool, error), inputLimit int, outputLimit int, closeOutput bool) error {
 	if inputLimit == 0 {
 		return nil
 	}
@@ -91,6 +91,15 @@ func IteratorToWriter(it Iterator, w Writer, transform func(inputObject interfac
 	err := w.Flush()
 	if err != nil {
 		return errors.Wrap(err, "error flushing output")
+	}
+
+	if closeOutput {
+		if c, ok := w.(interface{ Close() error }); ok {
+			err = c.Close()
+			if err != nil {
+				return errors.Wrap(err, "error closing output")
+			}
+		}
 	}
 
 	return nil

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -15,11 +15,11 @@ import (
 )
 
 var (
-	FilterNotNil = func(inputObject interface{}) (bool, error) {
-		return inputObject != nil, nil
+	FilterNotNil = func(object interface{}) (bool, error) {
+		return object != nil, nil
 	}
-	FilterString = func(inputObject interface{}) (bool, error) {
-		_, ok := inputObject.(string)
+	FilterString = func(object interface{}) (bool, error) {
+		_, ok := object.(string)
 		return ok, nil
 	}
 	WriterStdout = NewFunctionWriter(func(object interface{}) error {


### PR DESCRIPTION
New `InputF`, `OutputF`, and `CloseOutput` methods for the builder.  If close output is set, then the writer is closed once the run is complete.  ChannelWriter now accepts different types.