### PR TITLE
SyncWriter and TransactionWriter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   base:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     working_directory: /go/src/github.com/spatialcurrent/go-pipe
 jobs:
   pre_deps_golang:

--- a/pkg/pipe/SyncWriter.go
+++ b/pkg/pipe/SyncWriter.go
@@ -1,0 +1,81 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// SyncWriter wraps a mutex around an underlying writer, so writes happen sequentially.
+type SyncWriter struct {
+	writer Writer
+	mutex  *sync.Mutex
+}
+
+// NewSyncWriter returns a new SyncWriter.
+func NewSyncWriter(writer Writer) *SyncWriter {
+	return &SyncWriter{
+		writer: writer,
+		mutex:  &sync.Mutex{},
+	}
+}
+
+func (sw *SyncWriter) WriteObject(object interface{}) error {
+	sw.mutex.Lock()
+	defer sw.mutex.Unlock()
+	return sw.writer.WriteObject(object)
+}
+
+func (sw *SyncWriter) WriteObjects(objects interface{}) error {
+	values := reflect.ValueOf(objects)
+	if !values.IsValid() {
+		return errors.Errorf("objects %#v is not valid", objects)
+	}
+	if values.Kind() != reflect.Array && values.Kind() != reflect.Slice {
+		return errors.Errorf("objects is type %T, expecting kind array or slice", objects)
+	}
+	if values.IsNil() {
+		return errors.Errorf("objects %#v is nil", objects)
+	}
+	sw.mutex.Lock()
+	defer sw.mutex.Unlock()
+
+	if w, ok := sw.writer.(BatchWriter); ok {
+		err := w.WriteObjects(objects)
+		if err != nil {
+			return errors.Wrapf(err, "error writing objects %#v to underlying writer", objects)
+		}
+	} else {
+		for i := 0; i < values.Len(); i++ {
+			err := sw.writer.WriteObject(values.Index(i).Interface())
+			if err != nil {
+				return errors.Wrapf(err, "error writing object %d of %#v to underlying writer", i, objects)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (sw *SyncWriter) Flush() error {
+	sw.mutex.Lock()
+	defer sw.mutex.Unlock()
+	return sw.writer.Flush()
+}
+
+func (sw *SyncWriter) Close() error {
+	sw.mutex.Lock()
+	defer sw.mutex.Unlock()
+	if closer, ok := sw.writer.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}

--- a/pkg/pipe/SyncWriter_test.go
+++ b/pkg/pipe/SyncWriter_test.go
@@ -1,0 +1,45 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"sync"
+	//"time"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	//"github.com/stretchr/testify/require"
+)
+
+func TestSyncWriter(t *testing.T) {
+
+	values := make([]interface{}, 0)
+
+	sw := NewSyncWriter(NewFunctionWriter(func(object interface{}) error {
+		values = append(values, object)
+		return nil
+	}))
+
+	count := 1000
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(i int) {
+			err := sw.WriteObject(i)
+			if err != nil {
+				panic(err)
+			}
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+
+	assert.Lenf(t, values, count, "invalid length, expecting %d elements", count)
+}

--- a/pkg/pipe/SyncWriter_test.go
+++ b/pkg/pipe/SyncWriter_test.go
@@ -9,11 +9,9 @@ package pipe
 
 import (
 	"sync"
-	//"time"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	//"github.com/stretchr/testify/require"
 )
 
 func TestSyncWriter(t *testing.T) {

--- a/pkg/pipe/TransactionWriter.go
+++ b/pkg/pipe/TransactionWriter.go
@@ -84,13 +84,13 @@ func (tw *TransactionWriter) WriteObjects(objects interface{}) error {
 	}
 
 	if bw, ok := w.(BatchWriter); ok {
-		err := bw.WriteObjects(objects)
+		err = bw.WriteObjects(objects)
 		if err != nil {
 			return fmt.Errorf("error writing objects: %w", err)
 		}
 	} else {
 		for i := 0; i < values.Len(); i++ {
-			err := w.WriteObject(values.Index(i).Interface())
+			err = w.WriteObject(values.Index(i).Interface())
 			if err != nil {
 				return fmt.Errorf("error writing object %d: %w", i, err)
 			}

--- a/pkg/pipe/TransactionWriter.go
+++ b/pkg/pipe/TransactionWriter.go
@@ -1,0 +1,121 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// TransactionWriter opens up a transaction to the underlying writer
+// and closes the underlying writer after the objects are written.
+type TransactionWriter struct {
+	open  func() (Writer, error)
+	mutex *sync.RWMutex
+}
+
+// NewBufferWriter returns a new BufferWriter with the given capacity.
+func NewTransactionWriter(open func() (Writer, error)) (*TransactionWriter, error) {
+	if open == nil {
+		return nil, errors.New("cannot create TransactionWriter: open is nil")
+	}
+	tw := &TransactionWriter{
+		open:  open,
+		mutex: &sync.RWMutex{},
+	}
+	return tw, nil
+}
+
+func (tw *TransactionWriter) WriteObject(object interface{}) error {
+	tw.mutex.Lock()
+	defer tw.mutex.Unlock()
+
+	w, err := tw.open()
+	if err != nil {
+		return fmt.Errorf("error opening writer: %w", err)
+	}
+
+	err = w.WriteObject(object)
+	if err != nil {
+		return fmt.Errorf("error writing object: %w", err)
+	}
+
+	err = w.Flush()
+	if err != nil {
+		return fmt.Errorf("error flushing writer: %w", err)
+	}
+
+	if closer, ok := w.(interface{ Close() error }); ok {
+		err = closer.Close()
+		if err != nil {
+			return fmt.Errorf("error closing writer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (tw *TransactionWriter) WriteObjects(objects interface{}) error {
+
+	values := reflect.ValueOf(objects)
+	if !values.IsValid() {
+		return fmt.Errorf("objects %#v is not valid", objects)
+	}
+	if values.Kind() != reflect.Array && values.Kind() != reflect.Slice {
+		return fmt.Errorf("objects is type %T, expecting kind array or slice", objects)
+	}
+	if values.IsNil() {
+		return fmt.Errorf("objects %#v is nil", objects)
+	}
+
+	tw.mutex.Lock()
+	defer tw.mutex.Unlock()
+
+	w, err := tw.open()
+	if err != nil {
+		return fmt.Errorf("error opening writer: %w", err)
+	}
+
+	if bw, ok := w.(BatchWriter); ok {
+		err := bw.WriteObjects(objects)
+		if err != nil {
+			return fmt.Errorf("error writing objects: %w", err)
+		}
+	} else {
+		for i := 0; i < values.Len(); i++ {
+			err := w.WriteObject(values.Index(i).Interface())
+			if err != nil {
+				return fmt.Errorf("error writing object %d: %w", i, err)
+			}
+		}
+	}
+
+	err = w.Flush()
+	if err != nil {
+		return fmt.Errorf("error flushing writer: %w", err)
+	}
+
+	if closer, ok := w.(interface{ Close() error }); ok {
+		err := closer.Close()
+		if err != nil {
+			return fmt.Errorf("error closing writer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (tw *TransactionWriter) Flush() error {
+	return nil
+}
+
+func (tw *TransactionWriter) Close() error {
+	return nil
+}

--- a/pkg/pipe/TransactionWriter.go
+++ b/pkg/pipe/TransactionWriter.go
@@ -21,7 +21,7 @@ type TransactionWriter struct {
 	mutex *sync.RWMutex
 }
 
-// NewBufferWriter returns a new BufferWriter with the given capacity.
+// NewTransactionWriter returns a new TransactionWriter with the open function.
 func NewTransactionWriter(open func() (Writer, error)) (*TransactionWriter, error) {
 	if open == nil {
 		return nil, errors.New("cannot create TransactionWriter: open is nil")

--- a/pkg/pipe/TransactionWriter_test.go
+++ b/pkg/pipe/TransactionWriter_test.go
@@ -8,7 +8,6 @@
 package pipe
 
 import (
-	//"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/pipe/TransactionWriter_test.go
+++ b/pkg/pipe/TransactionWriter_test.go
@@ -1,0 +1,35 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	//"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionWriter(t *testing.T) {
+
+	values := make([]interface{}, 0)
+
+	tw, err := NewTransactionWriter(func() (Writer, error) {
+		fw := NewFunctionWriter(func(object interface{}) error {
+			values = append(values, object)
+			return nil
+		})
+		return fw, nil
+	})
+
+	require.NoError(t, err)
+
+	err = tw.WriteObject("a")
+	assert.Nil(t, err)
+	assert.Equal(t, []interface{}{"a"}, values)
+}


### PR DESCRIPTION
This PR adds a `SyncWriter` and `TransactionWriter`.  A `SyncWriter` allows multiple concurrent goroutines to write to an underlying writer in a sequential way.  A `TransactionWriter` calls a function that creates a temporary underlying writer that is closed after each write.