### PR TITLE
Add closer to TransactionWriter

### DIFF
--- a/pkg/pipe/TransactionWriter.go
+++ b/pkg/pipe/TransactionWriter.go
@@ -19,7 +19,7 @@ import (
 type TransactionWriter struct {
 	opener func() (Writer, error)
 	closer func(w Writer) error
-	mutex  *sync.RWMutex
+	mutex  *sync.Mutex
 }
 
 // NewTransactionWriter returns a new TransactionWriter with the opener function and optional closer function.
@@ -30,7 +30,7 @@ func NewTransactionWriter(opener func() (Writer, error), closer func(w Writer) e
 	tw := &TransactionWriter{
 		opener: opener,
 		closer: closer,
-		mutex:  &sync.RWMutex{},
+		mutex:  &sync.Mutex{},
 	}
 	return tw, nil
 }

--- a/pkg/pipe/TransactionWriter_test.go
+++ b/pkg/pipe/TransactionWriter_test.go
@@ -24,11 +24,38 @@ func TestTransactionWriter(t *testing.T) {
 			return nil
 		})
 		return fw, nil
-	})
+	}, nil)
 
 	require.NoError(t, err)
 
 	err = tw.WriteObject("a")
 	assert.Nil(t, err)
 	assert.Equal(t, []interface{}{"a"}, values)
+}
+
+func TestTransactionWriterCloser(t *testing.T) {
+
+	closed := 0
+	values := make([]interface{}, 0)
+
+	tw, err := NewTransactionWriter(
+		func() (Writer, error) {
+			fw := NewFunctionWriter(func(object interface{}) error {
+				values = append(values, object)
+				return nil
+			})
+			return fw, nil
+		},
+		func(w Writer) error {
+			closed += 1
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+
+	err = tw.WriteObject("a")
+	assert.Nil(t, err)
+	assert.Equal(t, []interface{}{"a"}, values)
+	assert.Equal(t, 1, closed)
 }


### PR DESCRIPTION
The `TransactionWriter` now includes an optional `closer` function that is called rather than calling `Close` on the underlying directly.  This `closer` function can be used to expand closing behavior or suppress the default behavior.