### PR TITLE
MultiWriter

### DIFF
--- a/pkg/pipe/MultiWriter.go
+++ b/pkg/pipe/MultiWriter.go
@@ -1,0 +1,81 @@
+// =================================================================
+//
+// Copyright (C) 2020 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+// MultiWriter creates a writer that duplicates its writes to all the provided writers.
+type MultiWriter struct {
+	writers []Writer
+}
+
+func NewMultiWriter(writers ...Writer) *MultiWriter {
+	return &MultiWriter{
+		writers: writers,
+	}
+}
+
+func (mw *MultiWriter) WriteObject(object interface{}) error {
+	for i, w := range mw.writers {
+		if err := w.WriteObject(object); err != nil {
+			return errors.Wrapf(err, "error writing object to writer %d", i)
+		}
+	}
+	return nil
+}
+
+func (mw *MultiWriter) WriteObjects(objects interface{}) error {
+	for i, w := range mw.writers {
+		if bw, ok := w.(BatchWriter); ok {
+			if err := bw.WriteObjects(objects); err != nil {
+				return errors.Wrapf(err, "error writing objects to writer %d", i)
+			}
+			continue
+		}
+		if slc, ok := objects.([]interface{}); ok {
+			for _, object := range slc {
+				if err := w.WriteObject(object); err != nil {
+					return errors.Wrapf(err, "error writing object to writer %d", i)
+				}
+			}
+			continue
+		}
+		values := reflect.ValueOf(objects)
+		if !values.IsValid() {
+			return errors.Errorf("objects %#v is not valid", objects)
+		}
+		if values.Kind() != reflect.Array && values.Kind() != reflect.Slice {
+			return errors.Errorf("objects is type %T, expecting kind array or slice", objects)
+		}
+		if values.IsNil() {
+			return errors.Errorf("objects %#v is nil", objects)
+		}
+		for i := 0; i < values.Len(); i++ {
+			err := w.WriteObject(values.Index(i).Interface())
+			if err != nil {
+				return fmt.Errorf("error writing object %d: %w", i, err)
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+func (mw *MultiWriter) Flush() error {
+	for i, w := range mw.writers {
+		if err := w.Flush(); err != nil {
+			return errors.Wrapf(err, "error flushing writer %d", i)
+		}
+	}
+	return nil
+}

--- a/pkg/pipe/MultiWriter_test.go
+++ b/pkg/pipe/MultiWriter_test.go
@@ -1,0 +1,86 @@
+// =================================================================
+//
+// Copyright (C) 2020 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiWriter(t *testing.T) {
+
+	a := make([]interface{}, 0)
+	b := make([]interface{}, 0)
+
+	mw := NewMultiWriter(
+		NewFunctionWriter(func(object interface{}) error {
+			a = append(a, object)
+			return nil
+		}),
+		NewFunctionWriter(func(object interface{}) error {
+			b = append(b, object)
+			return nil
+		}),
+	)
+
+	expected := make([]interface{}, 0)
+
+	count := 1000
+
+	for i := 0; i < count; i++ {
+		expected = append(expected, i)
+		//
+		err := mw.WriteObject(i)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	assert.Lenf(t, expected, count, "invalid length, expecting %d elements", count)
+	assert.Equal(t, expected, a)
+	assert.Equal(t, expected, b)
+}
+
+func TestMultiWriterInts(t *testing.T) {
+
+	a := make([]int, 0)
+	b := make([]int, 0)
+
+	mw := NewMultiWriter(
+		NewFunctionWriter(func(object interface{}) error {
+			if i, ok := object.(int); ok {
+				a = append(a, i)
+			}
+			return nil
+		}),
+		NewFunctionWriter(func(object interface{}) error {
+			if i, ok := object.(int); ok {
+				b = append(b, i)
+			}
+			return nil
+		}),
+	)
+
+	expected := make([]int, 0)
+
+	count := 1000
+
+	for i := 0; i < count; i++ {
+		expected = append(expected, i)
+		//
+		err := mw.WriteObject(i)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	assert.Lenf(t, expected, count, "invalid length, expecting %d elements", count)
+	assert.Equal(t, expected, a)
+	assert.Equal(t, expected, b)
+}

--- a/pkg/pipe/ReadAll.go
+++ b/pkg/pipe/ReadAll.go
@@ -1,0 +1,27 @@
+// =================================================================
+//
+// Copyright (C) 2020 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"io"
+)
+
+func ReadAll(it Iterator) ([]interface{}, error) {
+	objects := make([]interface{}, 0)
+	for {
+		object, err := it.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return objects, err
+		}
+		objects = append(objects, object)
+	}
+	return objects, nil
+}

--- a/pkg/pipe/ReadAll_test.go
+++ b/pkg/pipe/ReadAll_test.go
@@ -1,0 +1,24 @@
+// =================================================================
+//
+// Copyright (C) 2019 Spatial Current, Inc. - All Rights Reserved
+// Released as open source under the MIT License.  See LICENSE file.
+//
+// =================================================================
+
+package pipe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAll(t *testing.T) {
+	in := []interface{}{"a", "b", "3", 1, 2, 3}
+	it, err := NewSliceIterator(in)
+	require.NoError(t, err)
+	out, err := ReadAll(it)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}


### PR DESCRIPTION
This PR adds a `MultiWriter` writes every write to every one of the underlying writers.  Also adds the `ReadAll` func that reads all the objects left in an iterator and returns a slice of the objects.