### PR TITLE
close method for multiwriter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Spatial Current, Inc.
+Copyright (c) 2020 Spatial Current, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/pipe/MultiWriter.go
+++ b/pkg/pipe/MultiWriter.go
@@ -79,3 +79,14 @@ func (mw *MultiWriter) Flush() error {
 	}
 	return nil
 }
+
+func (mw *MultiWriter) Close() error {
+	for i, w := range mw.writers {
+		if closer, ok := w.(interface{ Close() error }); ok {
+			if err := closer.Close(); err != nil {
+				return errors.Wrapf(err, "error closing writer %d", i)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a `Close() error` method to the `MultiWriter` struct.